### PR TITLE
This fixes an calculation issue with promo codes.

### DIFF
--- a/app/code/community/Lfnds/Donation/Block/Checkout/Banner.php
+++ b/app/code/community/Lfnds/Donation/Block/Checkout/Banner.php
@@ -99,7 +99,7 @@ class Lfnds_Donation_Block_Checkout_Banner extends Mage_Core_Block_Template {
                 $total = Mage::getModel('checkout/cart')->getQuote()->getGrandTotal();
                 $localeCode = Mage::app()->getLocale()->getLocaleCode();
                 $symbols = Zend_Locale_Data::getList($localeCode, 'symbols');
-                
+
                 $receivers = $this->helper->getReceivers();
 
                 if (count($receivers) >= 3) {
@@ -108,7 +108,7 @@ class Lfnds_Donation_Block_Checkout_Banner extends Mage_Core_Block_Template {
                            ->getView()
                               ->assign('shopWidth', $banner_width)
                               ->assign('currencyDelimiter', $symbols['decimal'])
-                              ->assign('total', $total * 100)
+                              ->assign('total', round($total * 100))
                               ->assign('receivers', $receivers);
 
                     $template = $facade->renderTemplate();
@@ -137,6 +137,6 @@ class Lfnds_Donation_Block_Checkout_Banner extends Mage_Core_Block_Template {
     public function deactivateBanner() {
         $this->helper->deactivate();
     }
-    
-    
+
+
 }


### PR DESCRIPTION
Magento calculates the totals when using a promo code with less than cent values.
Whenever this is a case, the $total variable could be something like
`$total === 19.241`. This value multiplied by 100 for the frontend could lead to
wrong frontend values. The invoice value below the banner is 100 times higher than
it should be.
